### PR TITLE
feat: Add Firebase environment variables to Cloudtype deployment work…

### DIFF
--- a/.github/workflows/deploy-cloudtype.yml
+++ b/.github/workflows/deploy-cloudtype.yml
@@ -83,6 +83,11 @@ jobs:
             options:
               image: ${{ secrets.DOCKERHUB_USERNAME }}/job-crawler:latest
               ports: 3000
+              env:
+                - name: FIREBASE_CREDENTIAL_BASE64
+                  value: ${{ secrets.FIREBASE_CREDENTIAL_BASE64 }}
+                - name: FIREBASE_DATABASE_URL
+                  value: ${{ secrets.FIREBASE_DATABASE_URL }}
 
       - name: Deploy web-service to Cloudtype
         uses: cloudtype-github-actions/deploy@v1
@@ -95,3 +100,8 @@ jobs:
             options:
               image: ${{ secrets.DOCKERHUB_USERNAME }}/web-service:latest
               ports: 3000
+              env:
+                - name: FIREBASE_CREDENTIAL_BASE64
+                  value: ${{ secrets.FIREBASE_CREDENTIAL_BASE64 }}
+                - name: FIREBASE_DATABASE_URL
+                  value: ${{ secrets.FIREBASE_DATABASE_URL }}


### PR DESCRIPTION
- 시크릿 키는 깃허브에서만 관리하기 위해 cloudtype으로 env를 보내도록 actions 수정