### PR TITLE
Update /jobs api

### DIFF
--- a/apps/web-service/src/firebase/firebase.service.ts
+++ b/apps/web-service/src/firebase/firebase.service.ts
@@ -31,7 +31,7 @@ export class FirebaseService {
   async findAll(filters: Record<string, string | undefined>): Promise<Job[]> {
     let query: FirebaseFirestore.Query = this.db.collection('jobs');
 
-    const validFields = ['career', 'company', 'employmentType', 'period', 'title', 'url'];
+    const validFields = ['career', 'company', 'employmentType'];
 
     validFields.forEach((field) => {
       if (filters[field]) {

--- a/apps/web-service/src/jobs/entities/job.enums.ts
+++ b/apps/web-service/src/jobs/entities/job.enums.ts
@@ -1,0 +1,18 @@
+export enum EmploymentType {
+  FULL_TIME = '정규직',
+  PART_TIME = '비정규직',
+}
+
+export enum Company {
+  NAVER = 'NAVER',
+  KAKAO = 'KAKAO',
+  LINE = 'LINE',
+  COUPANG = 'COUPANG',
+  BAEMIN = 'BAEMIN',
+}
+
+export enum Career {
+  EXPERIENCED = '경력',
+  INTERN = '인턴',
+  NEWBIE = '신입',
+}

--- a/apps/web-service/src/jobs/jobs.controller.ts
+++ b/apps/web-service/src/jobs/jobs.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { JobsService } from './jobs.service';
+import { Career, Company, EmploymentType } from 'src/jobs/entities/job.enums';
 
 @Controller('jobs')
 export class JobsController {
@@ -7,20 +8,14 @@ export class JobsController {
 
   @Get()
   async findAll(
-    @Query('career') career?: string,
-    @Query('company') company?: string,
-    @Query('employmentType') employmentType?: string,
-    @Query('period') period?: string,
-    @Query('title') title?: string,
-    @Query('url') url?: string,
+    @Query('career') career?: Career,
+    @Query('company') company?: Company,
+    @Query('employmentType') employmentType?: EmploymentType,
   ) {
     return this.jobsService.findAll({
       career,
       company,
       employmentType,
-      period,
-      title,
-      url,
     });
   }
 

--- a/apps/web-service/src/jobs/jobs.service.ts
+++ b/apps/web-service/src/jobs/jobs.service.ts
@@ -1,16 +1,32 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { FirebaseService } from '../firebase/firebase.service';
 import { Job } from './entities/job.entity';
 
 @Injectable()
 export class JobsService {
+  private readonly logger = new Logger(JobsService.name);
+
   constructor(private readonly firebaseService: FirebaseService) {}
 
   async findAll(filters: Record<string, string | undefined>): Promise<Job[]> {
-    return this.firebaseService.findAll(filters);
+    try {
+      const result = this.firebaseService.findAll(filters);
+      this.logger.log(`Succeeded findAll: ${JSON.stringify(filters)}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Failed findAll: ${JSON.stringify(filters)}, ${error.message}`);
+      throw error;
+    }
   }
 
   async findOne(id: string): Promise<Job> {
-    return this.firebaseService.findOne(id);
+    try {
+      const result = this.firebaseService.findOne(id);
+      this.logger.log(`Succeeded findOne: ${id}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Failed findOne: ${id}, ${error.message}`);
+      throw error;
+    }
   }
 }

--- a/http/Find Jobs With Query Params.bru
+++ b/http/Find Jobs With Query Params.bru
@@ -5,11 +5,12 @@ meta {
 }
 
 get {
-  url: {{host}}/jobs?company=NAVER
+  url: {{host}}/jobs?company=NAVER&career=신입
   body: none
   auth: none
 }
 
 params:query {
   company: NAVER
+  career: 신입
 }


### PR DESCRIPTION
## 변경 사항

- findAll 의 파라미터를 career, company, employmentType 만 받도록 하고, 해당 파라미터를 enum 으로 정의
- findAll 서비스 메서드에 로깅 추가

### log example

```
[Nest] 20322  - 03/23/2025, 5:52:52 PM     LOG [JobsService] Succeeded findAll: {"career":"경력","company":"KAKAO"}
[Nest] 20322  - 03/23/2025, 5:53:07 PM     LOG [JobsService] Succeeded findAll: {"career":"경력","company":"NAVER"}
[Nest] 20322  - 03/23/2025, 5:53:10 PM     LOG [JobsService] Succeeded findAll: {"career":"신입","company":"NAVER"}
```
